### PR TITLE
Don't get confused by back references referring to the register named "N...

### DIFF
--- a/convert.lisp
+++ b/convert.lisp
@@ -633,7 +633,7 @@ when NAME is not NIL."
             ;; the same name and collect their respective numbers
             (loop for name in reg-names
                   for reg-index from 0
-                  when (string= name backref-name)
+                  when (and (stringp name) (string= name backref-name))
                   ;; NOTE: REG-NAMES stores register names in reversed
                   ;; order REG-NUM contains number of (any) registers
                   ;; seen so far; 1- will be done later

--- a/test/simple
+++ b/test/simple
@@ -364,3 +364,13 @@ characters if there's a match."
            (regex-replace-all (create-scanner "\\p{even}") "abcd" "+")
            (regex-replace-all (create-scanner "\\p{true}") "abcd" "+")))
    '("+b+d" "a+c+" "++++")))
+
+(handler-case
+    (progn
+      (scan '(:sequence
+              (:register "f")
+              (:register "o")
+              (:back-reference "NIL"))
+            "foo")
+      nil)
+  (error () t))


### PR DESCRIPTION
...IL".

This fixes issue #12.  Back references referring to the register named
"NIL" were being associated with the register with name NIL (the
symbol) instead of "NIL" (the string).  In this case NIL (symbol) is
supposed to indicate that the register is unnamed, but this was not
being checked with STRINGP before comparison with STRING=.
