### PR TITLE
Don't get confused by back references referring to the register named "N...

### DIFF
--- a/test/simple
+++ b/test/simple
@@ -364,3 +364,75 @@ characters if there's a match."
            (regex-replace-all (create-scanner "\\p{even}") "abcd" "+")
            (regex-replace-all (create-scanner "\\p{true}") "abcd" "+")))
    '("+b+d" "a+c+" "++++")))
+
+(handler-case
+    (progn
+      (scan '(:sequence
+              (:register "f")
+              (:register "o")
+              (:back-reference "NIL"))
+            "foo")
+      nil)
+  (error () t))
+
+(scan '(:sequence
+        (:register "f")
+        (:named-register nil "o")
+        (:back-reference "NIL"))
+      "foo")
+
+(scan '(:sequence
+        (:register "f")
+        (:named-register "NIL" "o")
+        (:back-reference nil))
+      "foo")
+
+(handler-case
+    (progn
+      (scan '(:sequence
+              (:register "f")
+              (:named-register "nil" "o")
+              (:back-reference nil))
+            "foo")
+      nil)
+  (error () t))
+
+(handler-case
+    (progn
+      (scan '(:sequence
+              (:register "f")
+              (:named-register "o" "o")
+              (:back-reference #\o))
+            "foo")
+      nil)
+  (error () t))
+
+(handler-case
+    (progn
+      (scan '(:sequence
+              (:register "f")
+              (:named-register #\o "o")
+              (:back-reference "o"))
+            "foo")
+      nil)
+  (error () t))
+
+(handler-case
+    (progn
+      (scan '(:sequence
+              (:register "f")
+              (:named-register "nil" "o")
+              (:back-reference))
+            "foo")
+      nil)
+  (error () t))
+
+(handler-case
+    (progn
+      (scan '(:sequence
+              (:register "f")
+              (:named-register)
+              (:back-reference "nil"))
+            "foo")
+      nil)
+  (error () t))


### PR DESCRIPTION
...IL".

This fixes issue #12.  Back references referring to the register named
"NIL" were being associated with the register objects with NIL for
their NAME slot (indicating an unnamed register) instead of those that
actually have "NIL" for a name.

One corollary of this patch is that back references may now refer to
named registers using symbols in addition to strings.  This is only
consistent, since named registers may themselves be named from
symbols.  To put it another way: names are strings, but they may be
represented in the parse tree with symbols.
