### PR TITLE
Fix Perl compatibility for (SPLIT ... :LIMIT -1).

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -594,6 +594,11 @@ structure with TARGET-STRING."
         ;; push start of match on list unless this would be an empty
         ;; string adjacent to the last element pushed onto the list
         (when (and limit
+                   ;; perlfunc(1) says
+                   ;;   If LIMIT is negative, it is treated as if
+                   ;;   it were instead arbitrarily large;
+                   ;;   as many fields as possible are produced.
+                   (plusp limit)
                    (>= (incf counter) limit))
           (return))
         (push match-start pos-list)

--- a/test/simple
+++ b/test/simple
@@ -142,6 +142,9 @@ frob")
 (equal (split ":" "a:b:c:d:e:f:g::" :limit 1000)
        '("a" "b" "c" "d" "e" "f" "g" "" ""))
 
+(equal (split ":" "a:b:c:d:e:f:g::" :limit -1)
+       '("a" "b" "c" "d" "e" "f" "g" "" ""))
+
 (equal (multiple-value-list (regex-replace "fo+" "foo bar" "frob"))
        (list "frob bar" t))
 


### PR DESCRIPTION
A negative limit means infinity.