### PR TITLE
Simplify cl-ppcre[-unicode].asd and shut up modern ASDFs

### DIFF
--- a/cl-ppcre-unicode.asd
+++ b/cl-ppcre-unicode.asd
@@ -29,13 +29,6 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :cl-user)
-
-(defpackage :cl-ppcre-unicode-asd
-  (:use :cl :asdf))
-
-(in-package :cl-ppcre-unicode-asd)
-
 (defsystem :cl-ppcre-unicode
   :description "Perl-compatible regular expression library (Unicode)"
   :author "Dr. Edi Weitz"
@@ -44,21 +37,19 @@
                         :serial t
                         :components ((:file "packages")
                                      (:file "resolver"))))
-  :depends-on (:cl-ppcre :cl-unicode))
+  :depends-on (:cl-ppcre :cl-unicode)
+  :in-order-to ((test-op (test-op :cl-ppcre-unicode/test))))
 
-(defsystem :cl-ppcre-unicode-test
+(defsystem :cl-ppcre-unicode/test
   :description "Perl-compatible regular expression library tests (Unicode)"
   :author "Dr. Edi Weitz"
   :license "BSD"
-  :depends-on (:cl-ppcre-unicode :cl-ppcre-test)
+  :depends-on (:cl-ppcre-unicode :cl-ppcre/test)
   :components ((:module "test"
                         :serial t
-                        :components ((:file "unicode-tests")))))
-
-(defmethod perform ((o test-op) (c (eql (find-system :cl-ppcre-unicode))))
-  ;; we must load CL-PPCRE explicitly so that the CL-PPCRE-TEST system
-  ;; will be found
-  (operate 'load-op :cl-ppcre)
-  (operate 'load-op :cl-ppcre-unicode-test)
-  (funcall (intern (symbol-name :run-all-tests) (find-package :cl-ppcre-test))
-           :more-tests (intern (symbol-name :unicode-test) (find-package :cl-ppcre-test))))
+                        :components ((:file "unicode-tests"))))
+  :perform (test-op (o c)
+             (funcall (intern (symbol-name :run-all-tests)
+                              (find-package :cl-ppcre-test))
+                      :more-tests (intern (symbol-name :unicode-test)
+                                          (find-package :cl-ppcre-test)))))

--- a/cl-ppcre.asd
+++ b/cl-ppcre.asd
@@ -29,13 +29,6 @@
 ;;; NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 ;;; SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-(in-package :cl-user)
-
-(defpackage :cl-ppcre-asd
-  (:use :cl :asdf))
-
-(in-package :cl-ppcre-asd)
-
 (defsystem :cl-ppcre
   :version "2.0.11"
   :description "Perl-compatible regular expression library"
@@ -67,9 +60,10 @@
                (:file "repetition-closures")
                #-:use-acl-regexp2-engine
                (:file "scanner")
-               (:file "api")))
+               (:file "api"))
+  :in-order-to ((test-op (test-op :cl-ppcre/test))))
 
-(defsystem :cl-ppcre-test
+(defsystem :cl-ppcre/test
   :description "Perl-compatible regular expression library tests"
   :author "Dr. Edi Weitz"
   :license "BSD"
@@ -78,8 +72,7 @@
                         :serial t
                         :components ((:file "packages")
                                      (:file "tests")
-                                     (:file "perl-tests")))))
-
-(defmethod perform ((o test-op) (c (eql (find-system :cl-ppcre))))
-  (operate 'load-op :cl-ppcre-test)
-  (funcall (intern (symbol-name :run-all-tests) (find-package :cl-ppcre-test))))
+                                     (:file "perl-tests"))))
+  :perform (test-op (o c)
+             (funcall (intern (symbol-name :run-all-tests)
+                              (find-package :cl-ppcre-test)))))


### PR DESCRIPTION
* Creating a package for the system definition is not necessary

* Rename secondary systems to ``.../test``

* Simplify dependency handling of test systems