### PR TITLE
Add *look-ahead-for-suffix*

### DIFF
--- a/api.lisp
+++ b/api.lisp
@@ -31,6 +31,10 @@
 
 (in-package :cl-ppcre)
 
+(defvar *look-ahead-for-suffix* t
+  "Controls whether scanners will optimistically look ahead for a
+  constant suffix of a regular expression, if there is one.")
+
 (defgeneric create-scanner (regex &key case-insensitive-mode
                                        multi-line-mode
                                        single-line-mode
@@ -120,7 +124,8 @@ modify its first argument \(but only if it's a parse tree)."))
                (end-string (end-string regex))
                ;; if we found a non-zero-length end-string we create an
                ;; efficient search function for it
-               (end-string-test (and end-string
+               (end-string-test (and *look-ahead-for-suffix*
+                                     end-string
                                      (plusp (len end-string))
                                      (if (= 1 (len end-string))
                                        (create-char-searcher

--- a/cl-ppcre.asd
+++ b/cl-ppcre.asd
@@ -37,7 +37,7 @@
 (in-package :cl-ppcre-asd)
 
 (defsystem :cl-ppcre
-  :version "2.0.11"
+  :version "2.1.0"
   :description "Perl-compatible regular expression library"
   :author "Dr. Edi Weitz"
   :license "BSD"

--- a/docs/index.html
+++ b/docs/index.html
@@ -103,6 +103,7 @@ href="http://weitz.de/regex-coach/">The Regex Coach</a>.
       <li><a href="#*optimize-char-classes*"><code>*optimize-char-classes*</code></a>
       <li><a href="#*allow-quoting*"><code>*allow-quoting*</code></a>
       <li><a href="#*allow-named-registers*"><code>*allow-named-registers*</code></a>
+      <li><a href="#*look-ahead-for-suffix*"><code>*look-ahead-for-suffix*</code></a>
     </ol>
     <li><a href="#misc">Miscellaneous</a>
     <ol>
@@ -1390,6 +1391,31 @@ lexical environment</a> at load time or at compile time so be careful
 to which value <code>*ALLOW-NAMED-REGISTERS*</code> is bound at that
 time.</blockquote>
 </blockquote>
+
+<p><br>[Special variable]
+<br><a class=none name="*look-ahead-for-suffix*"><b>*look-ahead-for-suffix*</b></a>
+
+<blockquote><br>Given a regular expression which has a constant
+suffix, such as <code>(a|b)+x</code> whose constant suffix
+is <code>x</code>, the scanners created
+by <a href="#create-scanner"><code>CREATE-SCANNER</code></a> will
+attempt to optimize by searching for the position of the suffix prior
+to performing the full match. In many cases, this is an optimization,
+especially when backtracking is involved on small strings. However, in
+other cases, such as incremental parsing of a very large string, this
+can cause a degradation in performance, because the entire string is
+searched for the suffix before an otherwise easy prefix match failure
+can occur. The variable <code>*LOOK-AHEAD-FOR-SUFFIX*</code>, whose
+default is <code>T</code>, can be used to selectively control this
+behavior.
+<p>
+Note: Due to the nature of <a href="http://www.lispworks.com/documentation/HyperSpec/Body/s_ld_tim.htm"><code>LOAD-TIME-VALUE</code></a> and the <a
+href="#compiler-macro">compiler macro for <code>SCAN</code> and other functions</a>, some
+scanners might be created in a <a
+href="http://www.lispworks.com/documentation/HyperSpec/Body/26_glo_n.htm#null_lexical_environment">null
+lexical environment</a> at load time or at compile time so be careful
+to which value <code>*LOOK-AHEAD-FOR-SUFFIX*</code> is bound at that
+time.</blockquote>
 
 <h4><a name="misc" class=none>Miscellaneous</a></h4>
 

--- a/packages.lisp
+++ b/packages.lisp
@@ -59,6 +59,7 @@
            :*allow-named-registers*
            :*optimize-char-classes*
            :*property-resolver*
+           :*look-ahead-for-suffix*
            :ppcre-error
            :ppcre-invocation-error
            :ppcre-syntax-error


### PR DESCRIPTION
This allows better performance for some scanning use-cases.

If you have a regex like `"a+x"`, CL-PPCRE will specially recognize that `#\x` should terminate the match. In that case, it'll create a special search function for it, which optimistically looks ahead for `#\x`. The two operative pieces of code are:

```
;;; from scanner.lisp -- license is that of CL-PPCRE

;;; from inside CREATE-SCANNER
              ;; if we found a non-zero-length end-string we create an
               ;; efficient search function for it
               (end-string-test (and end-string
                                     (plusp (len end-string))
                                     (if (= 1 (len end-string))
                                       (create-char-searcher
                                        (schar (str end-string) 0)
                                        (case-insensitive-p end-string))
                                       (create-bmh-matcher
                                        (str end-string)
                                        (case-insensitive-p end-string)))))

...

(defmacro char-searcher-aux (&key case-insensitive-p)
  "Auxiliary macro used by CREATE-CHAR-SEARCHER."
  (let ((char-compare (if case-insensitive-p 'char-equal 'char=)))
    `(lambda (start-pos)
      (declare (fixnum start-pos))
      (and (not (minusp start-pos))
           (loop for i of-type fixnum from start-pos below *end-pos*
                 thereis (and (,char-compare (schar *string* i) chr) i))))))
```

Unfortunately, if `*end-pos*` is very large, which is possible for very large strings being parsed (esp. ones being incrementally parsed), _and_ it happens that the character is never to be found, then this optimization will actually bite you considerably.

This is happening in the case of the Lisp library ALEXA, which uses CL-PPCRE to generate lexical analyzers. Each token search possibly calls this function, causing an `O(n^2)` search time in the length of the text. For a real-life use-case, this causes some lexing tasks to take 25 seconds when they could take but a fraction of a second. This would be avoided if it were greedy left-to-right searching.

My suggested fix would be to allow the user to control this behavior, with an additional keyword argument to `create-scanner`. Searching for the prefix is, I think, always OK. So no need to worry about that. Searching for the suffix, which may not exist, should be controlled. This is what the patch introduces.