### PR TITLE
Optimize WHITESPACEP, as it is often used.

### DIFF
--- a/util.lisp
+++ b/util.lisp
@@ -128,10 +128,13 @@ Perl's [\\w]."
 Same as Perl's [\\s].")
 
 (defun whitespacep (chr)
-  (declare #.*special-optimize-settings*)
+  (declare #. *special-optimize-settings*)
   "Tests whether a character is whitespace, i.e. whether it would
-match [\\s] in Perl."
-  (find chr +whitespace-char-string+ :test #'char=))
+  match [\\s] in Perl."
+  (macrolet ((expand ()
+               `(or . ,(loop for ch across +whitespace-char-string+
+                             collect `(char= chr ,ch)))))
+    (expand)))
 
 (defmacro maybe-coerce-to-simple-string (string)
   "Coerces STRING to a simple STRING unless it already is one."


### PR DESCRIPTION
For a test case using ESRAP (so not a microbenchmark)
I get these performance numbers:

;; Evaluation took:
;;   5.428 seconds of real time
;;   5.434423 seconds of total run time (5.343321 user, 0.091102 system)
;;   [ Run times consist of 0.099 seconds GC time, and 5.336 seconds non-GC time. ]
;;   100.11% CPU
;;   10,812,509,138 processor cycles
;;   6,030,089,632 bytes consed

;; cl-ppcre::whitespacep changed

;; Evaluation took:
;;   4.700 seconds of real time
;;   4.700945 seconds of total run time (4.657301 user, 0.043644 system)
;;   [ Run times consist of 0.109 seconds GC time, and 4.592 seconds non-GC time. ]
;;   100.02% CPU
;;   9,357,961,935 processor cycles
;;   6,013,307,376 bytes consed